### PR TITLE
feature/DSC-962 add nightly security scans

### DIFF
--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
   schedule:
-  # Runs daily at 00:30 - need to convert to UTC+8 (Singapore)
-  - cron: 30 16 * * *
+  # Runs daily at 1:00AM UTC+8 (Singapore)
+  - cron: 0 17 * * *
 
 jobs:
   security-pipeline: 

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -1,0 +1,15 @@
+name: Security Scans
+on:
+  push:
+    branches: [ main, 'release/**' ]
+    
+  workflow_dispatch:
+
+  schedule:
+  # Runs daily at 00:30 - need to convert to UTC+8 (Singapore)
+  - cron: 30 16 * * *
+
+jobs:
+  security-pipeline: 
+    uses: partior-sec-eng/security-scanning-pipeline/.github/workflows/security-scanning.yaml@main
+    secrets: inherit


### PR DESCRIPTION
### What does this PR do?
Add scheduled security scanning workflows as this repo is within the scope of security scanning.

### Where should the reviewer start?
The scheduled workflow calls the controller workflow at [security-scanning-pipeline](https://github.com/partior-sec-eng/security-scanning-pipeline).

### Why is it needed?
To ensure this repo is scanned for vulnerabilities daily and can be monitored by VM.
